### PR TITLE
Support Option#get => Option#getOrElse

### DIFF
--- a/velocity4s/src/main/scala/org/velocity4s/RewriteVelMethod.scala
+++ b/velocity4s/src/main/scala/org/velocity4s/RewriteVelMethod.scala
@@ -4,8 +4,7 @@ import java.lang.reflect.Method
 
 import org.apache.velocity.util.introspection.VelMethod
 
-
-private[velocity4s] class MapApplyVelMethod(method: Method) extends VelMethod {
+private[velocity4s] class RewriteVelMethod(method: Method, fun: (AnyRef, Array[AnyRef]) => AnyRef) extends VelMethod {
   override def getMethodName: String =
     method.getName
 
@@ -15,11 +14,6 @@ private[velocity4s] class MapApplyVelMethod(method: Method) extends VelMethod {
   override def isCacheable: Boolean =
     true
 
-  override def invoke(o: AnyRef, params: Array[AnyRef]): AnyRef = {
-    method.invoke(o, params(0)) match {
-      case None => null
-      case Some(v) => v.asInstanceOf[AnyRef]
-      case r => r
-    }
-  }
+  override def invoke(o: AnyRef, params: Array[AnyRef]): AnyRef =
+    fun(o, params)
 }

--- a/velocity4s/src/main/scala/org/velocity4s/ScalaOptionGetExecutor.scala
+++ b/velocity4s/src/main/scala/org/velocity4s/ScalaOptionGetExecutor.scala
@@ -1,0 +1,23 @@
+package org.velocity4s
+
+import org.apache.velocity.runtime.log.Log
+import org.apache.velocity.runtime.parser.node.PropertyExecutor
+import org.apache.velocity.util.introspection.Introspector
+
+class ScalaOptionGetExecutor(log: Log, introspector: Introspector, clazz: Class[_], property: String)
+  extends PropertyExecutor(log, introspector, clazz, property) {
+
+  override protected def discover(clazz: Class[_], property: String): Unit = {
+   setMethod(introspector.getMethod(clazz, property, Array.empty[AnyRef]))
+
+    if (!isAlive) {
+      super.discover(clazz, property)
+    }
+  }
+
+  override def execute(o: AnyRef): AnyRef =
+    if (isAlive)
+      o.asInstanceOf[Option[AnyRef]].getOrElse(null)
+    else
+      null
+}

--- a/velocity4s/src/test/scala/org/velocity4s/ScalaUberspectSpec.scala
+++ b/velocity4s/src/test/scala/org/velocity4s/ScalaUberspectSpec.scala
@@ -82,7 +82,7 @@ class ScalaUberspectSpec extends FunSpec {
       uberspect.getMethod(Map("key" -> "value"),
                           "get",
                           Array("key"),
-                          dummyInfo) should be (a [MapApplyVelMethod])
+                          dummyInfo) should be (a [RewriteVelMethod])
     }
 
     it("Map to no VelMethod(not get method)") {
@@ -91,7 +91,7 @@ class ScalaUberspectSpec extends FunSpec {
       uberspect.getMethod(Map("key" -> "value"),
                           "apply",
                           Array("key"),
-                          dummyInfo) should not be (a [MapApplyVelMethod])
+                          dummyInfo) should not be (a [RewriteVelMethod])
     }
 
     it("mutable.ArrayBuffer to VelMethod") {
@@ -109,7 +109,7 @@ class ScalaUberspectSpec extends FunSpec {
       uberspect.getMethod(mutable.Map("key" -> "value"),
                           "get",
                           Array("key"),
-                          dummyInfo) should be (a [MapApplyVelMethod])
+                          dummyInfo) should be (a [RewriteVelMethod])
     }
   }
 }

--- a/velocity4s/src/test/scala/org/velocity4s/Velocity4sScalaCollectionSpec.scala
+++ b/velocity4s/src/test/scala/org/velocity4s/Velocity4sScalaCollectionSpec.scala
@@ -136,7 +136,46 @@ class Velocity4sScalaCollectionSpec extends FunSpec with Velocity4sSpecSupport {
 
       merge(template, context) should be (empty)
     }
-  }
+
+    it("Scala Option Some get") {
+      val templateAsString = "$option.get"
+
+      val (engine, templateName) = newEngineWithTemplate(templateAsString)
+      val template = engine.getTemplate(templateName)
+      val context = newContext("option" -> Some("Velocity4s"))
+
+      merge(template, context) should be ("Velocity4s")
+    }
+
+    it("Scala Option Some get with parentheses") {
+      val templateAsString = "$option.get()"
+
+      val (engine, templateName) = newEngineWithTemplate(templateAsString)
+      val template = engine.getTemplate(templateName)
+      val context = newContext("option" -> Some("Velocity4s"))
+
+      merge(template, context) should be ("Velocity4s")
+    }
+
+    it("Scala Option None get") {
+      val templateAsString = "$option.get"
+
+      val (engine, templateName) = newEngineWithTemplate(templateAsString)
+      val template = engine.getTemplate(templateName)
+      val context = newContext("option" -> None)
+
+      merge(template, context) should be ("$option.get")
+    }
+
+    it("Scala Option None get with parentheses") {
+      val templateAsString = "$option.get()"
+
+      val (engine, templateName) = newEngineWithTemplate(templateAsString)
+      val template = engine.getTemplate(templateName)
+      val context = newContext("option" -> None)
+
+      merge(template, context) should be ("$option.get()")
+    }
 
     it("Scala mutable.ArrayBuffer foreach") {
       val templateAsString = """|#foreach ($name in $!names)
@@ -187,5 +226,5 @@ class Velocity4sScalaCollectionSpec extends FunSpec with Velocity4sSpecSupport {
       merge(template, context) should be ("Velocity4s")
 
     }
-
+  }
 }


### PR DESCRIPTION
in Velocity template, higher order function can not be used.

Because Option#getOrElse can not be called directly, should be a support to rewrite the Option#get to Option#getOrElse(null).
